### PR TITLE
move statement from "about" page

### DIFF
--- a/content/en/docs/Examples/_index.md
+++ b/content/en/docs/Examples/_index.md
@@ -7,10 +7,21 @@ description: >
 
 One of the best ways to see what Docsy can do, and learn how to configure a site with it, is to see some real projects. In addition to our provided Docsy Example Project, there are several live sites already using the theme. Please add your own examples once you've got a production site up and running with Docsy!
 
+## Docsy theme examples
+
+Example sites that have low to no custimzation:
+
 | Site  | Repo (if public)  |
 |---|---|
-|  URL for example site | https://github.com/google/docsy-example  |
+| [This Docsy documentation site](/docs) | https://github.com/google/docsy |
+| "Goldydocs" - a Docsy example site | https://github.com/google/docsy-example  |
 | https://www.kubeflow.org/  | https://github.com/kubeflow/website  |
-| https://agones.dev/site/ |   |
+| https://agones.dev/site/ | https://github.com/GoogleCloudPlatform/agones/tree/master/site |
 
+## Customized Docsy examples
 
+Example sites that include a moderate to high amount of customization:
+
+| Site  | Repo (if public)  |
+|---|---|
+| [Knative](https://knative.io) | https://github.com/knative/docs and https://github.com/knative/website |

--- a/content/en/docs/Examples/_index.md
+++ b/content/en/docs/Examples/_index.md
@@ -9,7 +9,7 @@ One of the best ways to see what Docsy can do, and learn how to configure a site
 
 ## Docsy theme examples
 
-Example sites that have low to no custimzation:
+Example sites that have low to no customization:
 
 | Site  | Repo (if public)  |
 |---|---|


### PR DESCRIPTION
relocate the statement from the "about" page: mentioned to use the docsy docs as an example

also added an adv section and link to Knative