### PR TITLE
"cloning example site" = "git submodule"

### DIFF
--- a/content/en/docs/Getting started/_index.md
+++ b/content/en/docs/Getting started/_index.md
@@ -77,7 +77,8 @@ To use the Docsy Hugo theme, you have a couple of options:
 
 ### Option 1: Clone the Docsy example site
 
-You can clone the Docsy site either by:
+The Example Site gives you a good starting point for building your docs site and is pre-configured to use the Docsy theme
+as a Git submodule. You can clone the Example Site either by:
 
 *  [Using the GitHub UI](#using-the-github-ui)
 *  [Using the command line](#using-the-command-line)


### PR DESCRIPTION
mention that by starting with a clone of the example site, you are get a site with Docsy pre-configured as a Git submodule